### PR TITLE
Update contrib doc to highlight allowing maintainer edits to PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ Note that contributions may be rejected on the basis of a contributor failing to
 1. **No force-pushes** or modifying the Git history in any way.
 2. If you have direct access to the repository, **create a branch for your changes** and create a pull request for that branch. If not, create a branch on a fork of the repository and create a pull request from there.
     * It's common practice for a repository to reject direct pushes to `master`, so make branching a habit!
+    * If PRing from your own fork, **ensure that "Allow edits from maintainers" is checked**. This gives permission for maintainers to commit changes directly to your fork, speeding up the review process.
 3. **Adhere to the prevailing code style**, which we enforce using [flake8](http://flake8.pycqa.org/en/latest/index.html).
     * Run `flake8` against your code **before** you push it. Your commit will be rejected by the build server if it fails to lint.
     * [Git Hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) are a powerful tool that can be a daunting to set up. Fortunately, [`pre-commit`](https://github.com/pre-commit/pre-commit) abstracts this process away from you and is provided as a dev dependency for this project. Run `pipenv run precommit` when setting up the project and you'll never have to worry about breaking the build for linting errors.
@@ -38,8 +39,9 @@ All projects evolve over time, and this contribution guide is no different. This
 A working environment for the [PyDis site](https://github.com/python-discord/site) is required to develop the bot. Instructions for setting up environments for both the site and the bot can be found on the PyDis Wiki:
   * [Site](https://wiki.pythondiscord.com/wiki/contributing/project/site)
   * [Bot](https://wiki.pythondiscord.com/wiki/contributing/project/bot)
+  * [Seasonalbot](https://github.com/python-discord/seasonalbot/wiki#development-environment)
 
-When pulling down changes from GitHub, remember to sync your environment using `pipenv sync --dev` to ensure you're using the most up-to-date versions the project's dependencies.
+When pulling down changes from GitHub, **remember to sync your environment** using `pipenv sync --dev` to ensure you're using the most up-to-date versions the project's dependencies.
 
 ### Type Hinting
 [PEP 484](https://www.python.org/dev/peps/pep-0484/) formally specifies type hints for Python functions, added to the Python Standard Library in version 3.5. Type hints are recognized by most modern code editing tools and provide useful insight into both the input and output types of a function, preventing the user from having to go through the codebase to determine these types. 
@@ -99,6 +101,8 @@ The project currently defines [`logging`](https://docs.python.org/3/library/logg
 Github [has introduced a new PR feature](https://github.blog/2019-02-14-introducing-draft-pull-requests/) that allows the PR author to mark it as a WIP. This provides both a visual and functional indicator that the contents of the PR are in a draft state and not yet ready for formal review.
 
 This feature should be utilized in place of the traditional method of prepending `[WIP]` to the PR title.
+
+As stated earlier, **ensure that "Allow edits from maintainers" is checked**. This gives permission for maintainers to commit changes directly to your fork, speeding up the review process.
 
 ## Footnotes
 


### PR DESCRIPTION
This is an important detail that many folks miss and should be in the contributor doc.

See: https://github.com/python-discord/organisation/issues/114