### PR TITLE
fix: Remove extra > in template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -14,7 +14,7 @@ assignees: ''
 
 # Justification
 
-<!-- Why do you think this would be a useful feature? -->>
+<!-- Why do you think this would be a useful feature? -->
 
 # Implementation
 


### PR DESCRIPTION
Removed an extra `>` in the template that would cause it to show up in the text below